### PR TITLE
correcting documentation for get_invoices method

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -200,7 +200,7 @@ h3. GET /api.xro/2.0/invoices (get_invoices)
 
 Gets all invoice records for a particular Xero customer.
 <pre><code>    gateway.get_invoices
-    gateway.get_invoices(1.month.ago) # modified since 1 month ago</code></pre>
+    gateway.get_invoices(:modified_since => 1.month.ago) # modified since 1 month ago</code></pre>
 
 
 


### PR DESCRIPTION
Tim I've just updated the README for xero_gateway to indicate that the get_invoices method expects hash params for the modified since parameter...
