### PR TITLE
Fixing broken ModifiedAfter param in get_contacts in gateway.rb

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -30,7 +30,7 @@ module XeroGateway
       request_params[:ContactID]     = options[:contact_id] if options[:contact_id]
       request_params[:ContactNumber] = options[:contact_number] if options[:contact_number]
       request_params[:OrderBy]       = options[:order] if options[:order]      
-      request_params[:ModifiedAfter] = Gateway.format_date_time(options[:updated_after]) if options[:updated_after]
+      request_params[:ModifiedAfter] = options[:updated_after] if options[:updated_after]
       request_params[:where]         = options[:where] if options[:where]
     
       response_xml = http_get(@client, "#{@xero_url}/Contacts", request_params)


### PR DESCRIPTION
Tim the get_contacts method was sending a string instead of a Time instance to http.rb which then throws a NoMethodError as it invokes the utc method on a string object.

```
# http.rb:31
headers['If-Modified-Since'] = params.delete(:ModifiedAfter).utc.strftime("%Y-%m-%dT%H:%M:%S") if params[:ModifiedAfter]
```

We (malclocke and I) are using webmock to test - which has picked this up, however you're stubbing http_get therefore http_request does not get called in your tests.  So you would not have seen this error...

Thanks
Abhinav
