### PR TITLE
Rename :updated_after to :modified_since in get_contacts

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -147,7 +147,7 @@ h3. GET /api.xro/2.0/contacts (get_contacts)
 
 Gets all contact records for a particular Xero customer.
 <pre><code>    gateway.get_contacts(:type => :all, :sort => :name, :direction => :desc)
-    gateway.get_contacts(:type => :all, :updated_after => 1.month.ago) # modified since 1 month ago</code></pre>
+    gateway.get_contacts(:type => :all, :modified_since => 1.month.ago) # modified since 1 month ago</code></pre>
 
 
 

--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -21,16 +21,21 @@ module XeroGateway
     # Retrieve all contacts from Xero
     #
     # Usage : get_contacts(:order => :name)
-    #         get_contacts(:updated_after => Time)
+    #         get_contacts(:modified_since => Time)
     #
     # Note  : modified_since is in UTC format (i.e. Brisbane is UTC+10)
     def get_contacts(options = {})
       request_params = {}
 
+      if !options[:updated_after].nil?
+        warn '[warning] :updated_after is depracated in XeroGateway#get_contacts.  Use :modified_since'
+        options[:modified_since] = options.delete(:updated_after)
+      end
+
       request_params[:ContactID]     = options[:contact_id] if options[:contact_id]
       request_params[:ContactNumber] = options[:contact_number] if options[:contact_number]
       request_params[:OrderBy]       = options[:order] if options[:order]      
-      request_params[:ModifiedAfter] = options[:updated_after] if options[:updated_after]
+      request_params[:ModifiedAfter] = options[:modified_since] if options[:modified_since]
       request_params[:where]         = options[:where] if options[:where]
     
       response_xml = http_get(@client, "#{@xero_url}/Contacts", request_params)


### PR DESCRIPTION
This renames the :updated_after param to :modified_since as mentioned previously.  Fires a warning if the old parameter is used.

The project we're working on is going to have fairly compete coverage of the xero_gateway gem, so we may have a few more pull requests to make.  Are you OK to keep receiving these as small changes or would you prefer one big pull when we're finished?

Thanks for the gem by the way, has made our lives a lot easier ;)

Malc
