### PR TITLE
Readme for credit notes

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -237,6 +237,59 @@ This method uses only a single API request to create/update multiple contacts.
 <pre><code>    invoices = [XeroGateway::Invoice.new(...), XeroGateway::Invoice.new(...)]
     result = gateway.create_invoices(invoices)</code></pre>
 
+h3. GET /api.xro/2.0/credit_note (get_credit_note_by_id)
+
+Gets an credit_note record for a specific Xero organisation
+<pre><code>    gateway.get_credit_note_by_id(credit_note_id)</code></pre>
+
+
+h3. GET /api.xro/2.0/credit_note (get_credit_note_by_number)
+
+Gets a credit note record for a specific Xero organisation
+<pre><code>    gateway.get_credit_note_by_number(credit_note_number)</code></pre>
+
+
+
+h3. GET /api.xro/2.0/credit_notes (get_credit_notes)
+
+Gets all credit note records for a particular Xero customer.
+<pre><code>    gateway.get_credit_notes
+    gateway.get_credit_notes(:modified_since => 1.month.ago) # modified since 1 month ago</code></pre>
+
+
+
+h3. PUT /api.xro/2.0/credit_note
+
+Inserts a credit note for a specific organization in Xero (Currently only adding new credit notes is allowed).
+
+CreditNote and line item totals are calculated automatically.
+<pre><code>    credit_note = gateway.build_credit_note({
+      :credit_note_type => "ACCRECCREDIT",
+      :credit_note_number => "YOUR CREDIT NOTE NUMBER",
+      :reference => "YOUR REFERENCE (NOT NECESSARILY UNIQUE!)",
+      :line_amount_types => "Inclusive" # "Inclusive", "Exclusive" or "NoTax"
+    })
+    credit_note.contact.name = "THE NAME OF THE CONTACT"
+    credit_note.contact.phone.number = "12345"
+    credit_note.contact.address.line_1 = "LINE 1 OF THE ADDRESS"    
+    credit_note.add_line_item({
+      :description => "THE DESCRIPTION OF THE LINE ITEM",
+      :unit_amount => 1000,
+      :tax_amount => 125,
+      :tracking_category => "THE TRACKING CATEGORY FOR THE LINE ITEM",
+      :tracking_option => "THE TRACKING OPTION FOR THE LINE ITEM"
+    })
+	
+		credit_note.create</code></pre>
+
+
+h3. PUT /api.xro/2.0/credit_notes
+
+Inserts multiple credit notes for a specific organization in Xero (currently only adding new credit notes is allowed).
+This method uses only a single API request to create/update multiple contacts.
+<pre><code>    credit_notes = [XeroGateway::CreditNote.new(...), XeroGateway::CreditNote.new(...)]
+    result = gateway.create_credit_notes(credit_notes)</code></pre>
+
 h3. GET /api.xro/2.0/accounts
 
 Gets all accounts for a specific organization in Xero.

--- a/lib/xero_gateway/credit_note.rb
+++ b/lib/xero_gateway/credit_note.rb
@@ -39,7 +39,7 @@ module XeroGateway
     attr_accessor :line_items_downloaded
   
     # All accessible fields
-    attr_accessor :credit_note_id, :credit_note_number, :type, :status, :date, :due_date, :reference, :line_amount_types, :currency_code, :line_items, :contact, :payments, :fully_paid_on, :amount_credited
+    attr_accessor :credit_note_id, :credit_note_number, :type, :status, :date, :reference, :line_amount_types, :currency_code, :line_items, :contact, :payments, :fully_paid_on, :amount_credited
 
     
     def initialize(params = {})
@@ -203,7 +203,7 @@ module XeroGateway
         return false if send(field) != other.send(field)
       end
       
-      ["date", "due_date"].each do |field|
+      ["date"].each do |field|
         return false if send(field).to_s != other.send(field).to_s
       end
       return true
@@ -230,7 +230,6 @@ module XeroGateway
         b.Type self.type
         contact.to_xml(b)
         b.Date CreditNote.format_date(self.date || Date.today)
-        b.DueDate CreditNote.format_date(self.due_date) if self.due_date
         b.Status self.status if self.status
         b.CreditNoteNumber self.credit_note_number if credit_note_number
         b.Reference self.reference if self.reference
@@ -255,7 +254,6 @@ module XeroGateway
           when "CurrencyCode" then credit_note.currency_code = element.text
           when "Contact" then credit_note.contact = Contact.from_xml(element)
           when "Date" then credit_note.date = parse_date(element.text)
-          when "DueDate" then credit_note.due_date = parse_date(element.text)
           when "Status" then credit_note.status = element.text
           when "Reference" then credit_note.reference = element.text
           when "LineAmountTypes" then credit_note.line_amount_types = element.text

--- a/test/stub_responses/credit_note.xml
+++ b/test/stub_responses/credit_note.xml
@@ -41,7 +41,6 @@
         <UpdatedDateUTC>2011-03-03T21:05:16.86</UpdatedDateUTC>
       </Contact>
       <Date>2010-08-23T00:00:00</Date>
-      <DueDate>2010-08-23T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <LineItems>

--- a/test/stub_responses/credit_notes.xml
+++ b/test/stub_responses/credit_notes.xml
@@ -29,7 +29,6 @@
         <Name>Red House Reads</Name>
       </Contact>
       <Date>2010-08-31T00:00:00</Date>
-      <DueDate>2010-08-31T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>199.75</SubTotal>
@@ -48,7 +47,6 @@
         <Name>Hot Chilly</Name>
       </Contact>
       <Date>2010-09-08T00:00:00</Date>
-      <DueDate>2010-09-08T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>24.00</SubTotal>
@@ -67,7 +65,6 @@
         <Name>Ridgeway University</Name>
       </Contact>
       <Date>2010-08-23T00:00:00</Date>
-      <DueDate>2010-08-23T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>500.00</SubTotal>
@@ -86,7 +83,6 @@
         <Name>Basket Case</Name>
       </Contact>
       <Date>2010-07-18T00:00:00</Date>
-      <DueDate>2010-07-18T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>100.00</SubTotal>
@@ -104,7 +100,6 @@
         <Name>Saatchi</Name>
       </Contact>
       <Date>2010-08-27T00:00:00</Date>
-      <DueDate>2010-08-27T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>222.22</SubTotal>
@@ -123,7 +118,6 @@
         <Name>Victor Power</Name>
       </Contact>
       <Date>2010-07-18T00:00:00</Date>
-      <DueDate>2010-07-18T00:00:00</DueDate>
       <Status>PAID</Status>
       <LineAmountTypes>Exclusive</LineAmountTypes>
       <SubTotal>50.00</SubTotal>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,7 +55,6 @@ module TestHelper
      credit_note = XeroGateway::CreditNote.new({
        :type => "ACCRECCREDIT",
        :date => Time.now,
-       :due_date => Date.today + 20,
        :credit_note_number => STUB_XERO_CALLS ? "CN-0153" : "#{Time.now.to_f}",
        :reference => "YOUR REFERENCE (NOT NECESSARILY UNIQUE!)",
        :line_items_downloaded => with_line_items

--- a/test/unit/credit_note_test.rb
+++ b/test/unit/credit_note_test.rb
@@ -135,7 +135,6 @@ class CreditNoteTest < Test::Unit::TestCase
     # Test credit_note defaults.
     assert_equal('ACCRECCREDIT', credit_note.type)
     assert_kind_of(Date, credit_note.date)
-    assert_kind_of(Date, credit_note.due_date)
     assert_equal('12345', credit_note.credit_note_number)
     assert_equal('MY REFERENCE FOR THIS CREDIT NOTE', credit_note.reference)
     assert_equal("Exclusive", credit_note.line_amount_types)
@@ -228,7 +227,6 @@ class CreditNoteTest < Test::Unit::TestCase
       credit_note_params = {
         :type => 'ACCRECCREDIT',
         :date => Date.today,
-        :due_date => Date.today + 20,
         :credit_note_number => '12345',
         :reference => "MY REFERENCE FOR THIS CREDIT NOTE",
         :line_amount_types => "Exclusive"


### PR DESCRIPTION
Tim - I have updated the readme, and also removed the :due_date attribute from credit notes which is available via the API, however is not documented as an element of credit notes in the API reference.  I have confirmed with the Xero API manager that :due_date is not supposed to be available in credit notes and will be removed from API in the future.
