### PR TITLE
Handle 'rate limit exceeded' OAuth error

### DIFF
--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -85,10 +85,14 @@ module XeroGateway
         description   = error_details["oauth_problem_advice"].first
       
         # see http://oauth.pbworks.com/ProblemReporting
-        # Xero only appears to return either token_expired or token_rejected
+        # In addition to token_expired and token_rejected, Xero also returns
+        # 'rate limit exceeded' when more than 60 requests have been made in
+        # a second.
         case (error_details["oauth_problem"].first)
           when "token_expired"        then raise OAuth::TokenExpired.new(description)
           when "token_rejected"       then raise OAuth::TokenInvalid.new(description)
+          when "rate limit exceeded"  then raise OAuth::RateLimitExceeded.new(description)
+          else raise OAuth::UnknownError.new(error_details["oauth_problem"].first + ':' + description)
         end
       end
       

--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -10,6 +10,8 @@ module XeroGateway
     
     class TokenExpired < StandardError; end
     class TokenInvalid < StandardError; end
+    class RateLimitExceeded < StandardError; end
+    class UnknownError < StandardError; end
         
     unless defined? XERO_CONSUMER_OPTIONS
       XERO_CONSUMER_OPTIONS = {

--- a/test/stub_responses/bogus_oauth_error
+++ b/test/stub_responses/bogus_oauth_error
@@ -1,0 +1,1 @@
+oauth_problem=bogus_error&oauth_problem_advice=bogus%20error

--- a/test/stub_responses/rate_limit_exceeded
+++ b/test/stub_responses/rate_limit_exceeded
@@ -1,0 +1,1 @@
+oauth_problem=rate%20limit%20exceeded&oauth_problem_advice=please%20wait%20before%20retrying%20the%20xero%20api

--- a/test/unit/gateway_test.rb
+++ b/test/unit/gateway_test.rb
@@ -32,6 +32,22 @@ class GatewayTest < Test::Unit::TestCase
         @gateway.get_accounts
       end
     end
+
+    should "handle rate limit exceeded" do
+      XeroGateway::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("rate_limit_exceeded"), :code => "401"))
+
+      assert_raises XeroGateway::OAuth::RateLimitExceeded do
+        @gateway.get_accounts
+      end
+    end
+
+    should "handle unknown errors" do
+      XeroGateway::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("bogus_oauth_error"), :code => "401"))
+
+      assert_raises XeroGateway::OAuth::UnknownError do
+        @gateway.get_accounts
+      end
+    end
     
     should "handle ApiExceptions" do
       XeroGateway::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => get_file_as_string("api_exception.xml"), :code => "400"))


### PR DESCRIPTION
The gem assumes that Xero will only send two types of 401 response, `token_invalid` or `token_expired`.  In fact, there is at least one other, `rate limit exceeded`, see http://blog.xero.com/developer/api-overview/

Attached pull request will raise `XeroGateway::OAuth::RateLimitExceeded` if this error is encountered.

In case there are any other possible undocumented errors hidden in the Xero API I have also added a fall through which raises `XeroGateway::OAuth::UnkownError`.  This will stop execution continuing and raising exceptions trying to XML parse `nil` response bodies, which is the problem we encountered when exceeding the rate limit.

Malc
