### PR TITLE
gem install no longer install oauth dependency

### DIFF
--- a/xero_gateway.gemspec
+++ b/xero_gateway.gemspec
@@ -9,4 +9,5 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
   s.authors  = ["Tim Connor", "Nik Wakelin"]
   s.files = ["LICENSE", "Rakefile", "README.textile", "xero_gateway.gemspec"] + Dir['**/*.rb'] + Dir['**/*.crt']
+  s.add_dependency('oauth', '>= 0.3.6')
 end


### PR DESCRIPTION
Looks like 7360b286b54f6b10d8a4 removed the dependency on `oauth` from the gemspec file.  Since 2.0.4 xero_gateway no longer pulls in the `oauth` gem as a dependency from `gem install`:

```
$ gem dependency xero_gateway -v 2.0.3
Gem xero_gateway-2.0.3
  builder (>= 2.1.2, runtime)
  oauth (>= 0.3.6, runtime)

$ gem dependency xero_gateway -v 2.0.4
Gem xero_gateway-2.0.4

$ gem dependency xero_gateway -v 2.0.5
Gem xero_gateway-2.0.5
```

This commit reinstates the gem dependency to the gemspec.

Malc
