### PR TITLE
Fix tracking category single option

### DIFF
--- a/lib/xero_gateway/tracking_category.rb
+++ b/lib/xero_gateway/tracking_category.rb
@@ -71,6 +71,7 @@ module XeroGateway
             element.children.each do |option_child|
               tracking_category.options << option_child.children.detect {|c| c.name == "Name"}.text
             end
+          when "Option" then tracking_category.options << element.text
         end
       end
       tracking_category              

--- a/test/unit/tracking_category_test.rb
+++ b/test/unit/tracking_category_test.rb
@@ -17,7 +17,22 @@ class TrackingCategoryTest < Test::Unit::TestCase
     # Check the tracking category details
     assert_equal tracking_category, result_tracking_category
   end
-  
+
+  def test_build_and_parse_xml_from_line_item
+    tracking_category = create_test_line_item_tracking_category
+
+    # Generate the XML message
+    tracking_category_as_xml = tracking_category.to_xml_for_invoice_messages
+
+    # Parse the XML message and retrieve the tracking category element
+    tracking_category_element = REXML::XPath.first(REXML::Document.new(tracking_category_as_xml), "/TrackingCategory")
+
+    # Build a new tracking category from the XML
+    result_tracking_category = XeroGateway::TrackingCategory.from_xml(tracking_category_element)
+
+    # Check the tracking category details
+    assert_equal tracking_category, result_tracking_category
+  end
   
   private
   
@@ -25,6 +40,13 @@ class TrackingCategoryTest < Test::Unit::TestCase
     tracking_category = XeroGateway::TrackingCategory.new
     tracking_category.name = "REGION"
     tracking_category.options = ["NORTH", "SOUTH", "CENTRAL"]
+    tracking_category
+  end
+
+  def create_test_line_item_tracking_category
+    tracking_category = XeroGateway::TrackingCategory.new
+    tracking_category.name = "REGION"
+    tracking_category.options = ["NORTH"]
     tracking_category
   end
 end


### PR DESCRIPTION
When creating a `TrackingCategory` from an `Invoice` or `CreditNote`, the options element is left blank.

This adds a matcher to `TrackingCategory.from_xml` to create a single option if there is an `<Option>` tag present.
