### PR TITLE
Handle no certificate registered error

### DIFF
--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -111,19 +111,18 @@ module XeroGateway
 
         doc = REXML::Document.new(raw_response, :ignore_whitespace_nodes => :all)
 
-        if doc.root.name == "ApiException"
+        if doc.root.nil? || doc.root.name != "ApiException"
+
+          raise "Unparseable 400 Response: #{raw_response}"
+
+        else
 
           raise ApiException.new(doc.root.elements["Type"].text,
                                  doc.root.elements["Message"].text,
                                  request_xml,
                                  raw_response)
 
-        else
-
-          raise "Unparseable 400 Response: #{raw_response}"
-
         end
-
       end
 
       def handle_object_not_found!(response, request_url)

--- a/test/stub_responses/no_certificates_registered
+++ b/test/stub_responses/no_certificates_registered
@@ -1,0 +1,1 @@
+No%20certificates%20have%20been%20registered%20for%20the%20consumer

--- a/test/unit/gateway_test.rb
+++ b/test/unit/gateway_test.rb
@@ -89,6 +89,13 @@ class GatewayTest < Test::Unit::TestCase
       end
     end
 
+    should "handle no root element" do
+      XeroGateway::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => get_file_as_string("no_certificates_registered"), :code => 400))
+
+      assert_raises RuntimeError do
+        response = @gateway.create_invoice(XeroGateway::Invoice.new)
+      end
+    end
   end
 
   def test_unknown_error_handling


### PR DESCRIPTION
Hey guys,

I had no public key certificate against a test xero account I was using, it had expired or been removed without being updated. 

I was seeing was a NoMethodError caused by a REXML::Document instance method returning nil on [this line](https://github.com/tlconnor/xero_gateway/blob/master/lib/xero_gateway/http.rb#L114) as there were [no children](http://ruby-doc.org/stdlib-1.9.3/libdoc/rexml/rdoc/REXML/Document.html#method-i-root). 

It was not immediately apparent what was causing the problem so I have added a couple of lines to output the response body in this case. Hopefully it will save someone some time in the future!

Cheers
