### PR TITLE
ignore personal or environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .bundle
 .rvmrc
+.ruby-version
+.ruby-gemset
 .rbenv-version


### PR DESCRIPTION
allowing other developers to use [rvm](https://rvm.io) or other Ruby version managers, without having to "pollute" their development space.