### PR TITLE
Add payment retrieval functionality and process IsReconciled properly

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -585,6 +585,16 @@ module XeroGateway
       parse_response(response_xml, {:request_params => request_params}, {:request_signature => 'GET/payments'})
     end
 
+
+    #
+    # Gets a single Payment for a specific organsation in Xero
+    #
+    def get_payment(payment_id, options = {})
+      request_params = {}
+      response_xml = http_get(client, "#{xero_url}/Payments/#{payment_id}", request_params)
+      parse_response(response_xml, {:request_params => request_params}, {:request_signature => 'GET/payments'})
+    end
+
     # Retrieves reports from Xero
     #
     # Usage : get_report("BankStatement", bank_account_id: "AC993F75-035B-433C-82E0-7B7A2D40802C")

--- a/lib/xero_gateway/payment.rb
+++ b/lib/xero_gateway/payment.rb
@@ -7,7 +7,8 @@ module XeroGateway
     attr_reader :errors
 
     # All accessible fields
-    attr_accessor :invoice_id, :invoice_number, :account_id, :code, :payment_id, :payment_type, :date, :amount, :reference, :currency_rate, :updated_at
+    attr_accessor :invoice_id, :invoice_number, :account_id, :code, :payment_id, :payment_type, :date, :amount, :reference, :currency_rate, :updated_at, :reconciled
+    alias_method :reconciled?, :reconciled
 
     def initialize(params = {})
       @errors ||= []
@@ -31,6 +32,7 @@ module XeroGateway
           when 'Invoice'
             payment.invoice_id = element.elements["//InvoiceID"].text
             payment.invoice_number = element.elements["//InvoiceNumber"].text
+          when 'IsReconciled'   then payment.reconciled = true
           when 'Account'        then payment.account_id = element.elements["//AccountID"].text
         end
       end
@@ -67,6 +69,10 @@ module XeroGateway
         b.Amount            self.amount         if self.amount
         b.CurrencyRate      self.currency_rate  if self.currency_rate
         b.Reference         self.reference      if self.reference
+
+        if self.reconciled?
+          b.IsReconciled true
+        end
 
         b.Date              self.class.format_date(self.date || Date.today)
       end

--- a/test/stub_responses/payments.xml
+++ b/test/stub_responses/payments.xml
@@ -12,6 +12,7 @@
       <CurrencyRate>1.000000</CurrencyRate>
       <PaymentType>ACCRECPAYMENT</PaymentType>
       <Status>AUTHORISED</Status>
+      <IsReconciled>true</IsReconciled>
       <UpdatedDateUTC>2010-11-12T14:36:22.537</UpdatedDateUTC>
       <Account>
         <AccountID>ac993f75-035b-433c-82e0-7b7a2d40802c</AccountID>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -133,6 +133,7 @@ module TestHelper
       :date             => Date.today.to_time,
       :invoice_id       => 'i99i9iii-9999-99i9-9ii9-iiiiii9i9999',
       :invoice_number   => 'INV-0001',
+      :reconciled       => true,
     }.merge(params)
     XeroGateway::Payment.new(params)
   end

--- a/test/unit/gateway_test.rb
+++ b/test/unit/gateway_test.rb
@@ -56,6 +56,13 @@ class GatewayTest < Test::Unit::TestCase
       assert result.response_item.first.is_a? XeroGateway::Payment
     end
 
+    should :get_payment do
+      XeroGateway::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("payments.xml"), :code => "200"))
+      result = @gateway.get_payment('1234')
+      assert result.response_item.first.is_a? XeroGateway::Payment
+    end
+
+
     should :get_contacts do
       XeroGateway::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("contacts.xml"), :code => "200"))
       result = @gateway.get_contacts

--- a/test/unit/payment_test.rb
+++ b/test/unit/payment_test.rb
@@ -34,6 +34,7 @@ class PaymentTest < Test::Unit::TestCase
       assert_equal 'i99i9iii-9999-99i9-9ii9-iiiiii9i9999', payment.invoice_id
       assert_equal 'INV-0001', payment.invoice_number
       assert_equal 'o99o9ooo-9999-99o9-9oo9-oooooo9o9999', payment.account_id
+      assert payment.reconciled?
     end
   end
 


### PR DESCRIPTION
This could probably be two pull requests; but as we were working with Xero we ran into a lovely issue where in order to update invoices, we needed to delete the payment and then re-create it in order to change invoices that were marked as paid already.

In our first pass, we simply cached the version of the Payment that was retrieved with the Invoice, deleted it, and re-created the cached version. Easy Peasy! 

However, we soon discovered the Invoices API they provide doesn't include the IsReconciled data, which our accountant used to determine what records needed to be looked at. Oops :cry:. 

This mean we needed to retrieve a Payment from the Payment endpoint; however it seems that the XeroAPI no longer respects the `PaymentID` query parameter to filter a payment to a single payment. 

So we wrote `Gateway#get_payment` and added the `IsReconciled` field to both `Payment#to_xml` and  `Payment#from_xml`

Let us know what you think,

 - @etlund and @zspencer