### PR TITLE
Payment#reconciled is set only if IsReconciled XML is 'true'

### DIFF
--- a/lib/xero_gateway/payment.rb
+++ b/lib/xero_gateway/payment.rb
@@ -32,7 +32,7 @@ module XeroGateway
           when 'Invoice'
             payment.invoice_id = element.elements["//InvoiceID"].text
             payment.invoice_number = element.elements["//InvoiceNumber"].text
-          when 'IsReconciled'   then payment.reconciled = true
+          when 'IsReconciled'   then payment.reconciled = (element.text == "true")
           when 'Account'        then payment.account_id = element.elements["//AccountID"].text
         end
       end


### PR DESCRIPTION
We had seen cases where `IsReconciled` did not come in for Payments, so we
assumed that any time IsReconciled *is* set then the payment was reconciled.

This is not, apparently, true. IsReconciled can sometimes be a string value of
`"false"`; so we are doing a string comparison to ensure that the IsReconciled
is the string value of `"true"`