### PR TITLE
Xero sends some OAuth errors as 503 errors

### DIFF
--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -79,6 +79,9 @@ module XeroGateway
             handle_oauth_error!(response)
           when 404
             handle_object_not_found!(response, url)
+          when 503
+            # Xero sends certain oauth errors back as 500 errors
+            handle_oauth_error!(response)
           else
             raise "Unknown response code: #{response.code.to_i}"
         end


### PR DESCRIPTION
We pushed out our integration and discovered that even though we were exceeding the rate limit, we weren't getting the expected exception for it. Instead we were getting `RuntimeError`; which makes it a bit difficult to ignore the errors in our monitoring software :).


Zee + @etlund