### PR TITLE
Swaps out alias_method_chain for Module#prepend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
  - "1.9.3"
  - "2.2.4"
- - "2.3.0"
+ - "2.3.1"
 before_install:
   - gem update --system 2.2.2
   - gem --version

--- a/lib/oauth/oauth_consumer.rb
+++ b/lib/oauth/oauth_consumer.rb
@@ -1,14 +1,30 @@
 module OAuth
   class Consumer
-    
-    def http_with_ssl_client_certificates(*args)
-      @http ||= http_without_ssl_client_certificates(*args).tap do |http|
-        http.cert = options[:ssl_client_cert]
-        http.key  = options[:ssl_client_key]
+
+    if RUBY_VERSION >= "2.0.0"
+
+      # we got Module#prepend, let's use it
+      module ClientCertificateExtensions
+        def http
+          super.tap do |http|
+            http.cert = options[:ssl_client_cert]
+            http.key  = options[:ssl_client_key]
+          end
+        end
       end
+
+      prepend ClientCertificateExtensions
+
+    else
+      def http_with_ssl_client_certificates(*args)
+        @http ||= http_without_ssl_client_certificates(*args).tap do |http|
+          http.cert = options[:ssl_client_cert]
+          http.key  = options[:ssl_client_key]
+        end
+      end
+
+      alias_method_chain :http, :ssl_client_certificates
     end
-  
-    alias_method_chain :http, :ssl_client_certificates
-    
+
   end
 end


### PR DESCRIPTION
(in Ruby versions that support it)