### PR TITLE
After a get_invoices, Invoice#line_items returned 'true', not a LineItem

### DIFF
--- a/lib/xero_gateway/invoice.rb
+++ b/lib/xero_gateway/invoice.rb
@@ -236,8 +236,8 @@ module XeroGateway
         response = @gateway.get_invoice(invoice_id)
         raise InvoiceNotFoundError, "Invoice with ID #{invoice_id} not found in Xero." unless response.success? && response.invoice.is_a?(XeroGateway::Invoice)
 
-        @line_items = response.invoice.line_items
         @line_items_downloaded = true
+        @line_items = response.invoice.line_items
       end
   end
 end

--- a/test/integration/get_invoices_test.rb
+++ b/test/integration/get_invoices_test.rb
@@ -2,91 +2,100 @@ require File.dirname(__FILE__) + '/../test_helper'
 
 class GetInvoicesTest < Test::Unit::TestCase
   include TestHelper
-  
+
   INVALID_INVOICE_ID = "99999999-9999-9999-9999-999999999999" unless defined?(INVALID_INVOICE_ID)
-  
+  INVOICE_GET_URL = /\/Invoices\/a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999/
+
   def setup
     @gateway = XeroGateway::Gateway.new(CONSUMER_KEY, CONSUMER_SECRET)
-    
+
     if STUB_XERO_CALLS
       @gateway.xero_url = "DUMMY_URL"
-      
+
       @gateway.stubs(:http_get).with {|client, url, params| url =~ /Invoices/ }.returns(get_file_as_string("invoices.xml"))
       @gateway.stubs(:http_put).with {|client, url, body, params| url =~ /Invoices$/ }.returns(get_file_as_string("create_invoice.xml"))
 
       # Get an invoice with an invalid ID number.
       @gateway.stubs(:http_get).with {|client, url, params| url =~ Regexp.new("Invoices/#{INVALID_INVOICE_ID}") }.returns(get_file_as_string("invoice_not_found_error.xml"))
+
+      # Get referenced invoice with line items
+      @gateway.stubs(:http_get).with {|client, url, params, headers| url =~ INVOICE_GET_URL && headers["Accept"].blank? }.returns(get_file_as_string("invoice.xml"))
     end
   end
-  
+
   def test_get_invoices
     # Make sure there is an invoice in Xero to retrieve
     invoice = @gateway.create_invoice(dummy_invoice).invoice
-    
+
     result = @gateway.get_invoices
     assert result.success?
     assert !result.request_params.nil?
-    assert !result.response_xml.nil?  
+    assert !result.response_xml.nil?
     assert result.invoices.collect {|i| i.invoice_number}.include?(invoice.invoice_number)
     assert result.invoices[0].sent_to_contact == true
     assert result.invoices[1].sent_to_contact == false
   end
-  
+
   def test_get_invoices_with_modified_since_date
     # Create a test invoice
     invoice = dummy_invoice
     @gateway.create_invoice(invoice)
-    
+
     # Check that it is returned
     result = @gateway.get_invoices(:modified_since => Date.today - 1)
     assert result.success?
     assert !result.request_params.nil?
-    assert !result.response_xml.nil?    
+    assert !result.response_xml.nil?
     assert result.request_params.keys.include?(:ModifiedAfter) # make sure the flag was sent
     assert result.invoices.collect {|response_invoice| response_invoice.invoice_number}.include?(invoice.invoice_number)
   end
-  
+
   def test_line_items_downloaded_set_correctly
     # No line items.
     response = @gateway.get_invoices
     assert_equal(true, response.success?)
-    
+
     invoice = response.invoices.first
     assert_kind_of(XeroGateway::Invoice, invoice)
     assert_equal(false, invoice.line_items_downloaded?)
+    assert_equal 1, invoice.line_items.size
+    line_item = invoice.line_items.first
+    assert_kind_of(XeroGateway::LineItem, line_item)
+    assert_equal 'A LINE ITEM', line_item.description
+    assert_equal 12.34, line_item.unit_amount
   end
-  
+
   # Make sure that a reference to gateway is passed when the get_invoices response is parsed.
   def test_get_contacts_gateway_reference
     result = @gateway.get_invoices
     assert(result.success?)
     assert_not_equal(0, result.invoices.size)
-    
+
     result.invoices.each do | invoice |
       assert(invoice.gateway === @gateway)
     end
   end
-  
+
   # Test to make sure that we correctly error when an invoice doesn't have an ID.
   # This should usually never be ecountered, but might if a draft invoice is deleted from Xero.
   def test_to_ensure_that_an_invoice_with_invalid_id_errors
     # Make sure there is an invoice to retrieve, even though we will mangle it later.
     invoice = @gateway.create_invoice(dummy_invoice).invoice
-    
+
     result = @gateway.get_invoices
     assert_equal(true, result.success?)
-    
+
     invoice = result.invoices.first
     assert_equal(false, invoice.line_items_downloaded?)
-    
+
     # Mangle invoice_id to invalid one.
     invoice.invoice_id = INVALID_INVOICE_ID
-    
+
     # Make sure we fail here.
     line_items = nil
     assert_raise(XeroGateway::InvoiceNotFoundError) { line_items = invoice.line_items }
     assert_nil(line_items)
-    
+
   end
-  
+
 end

--- a/test/stub_responses/invoice.xml
+++ b/test/stub_responses/invoice.xml
@@ -1,1 +1,83 @@
-<?xml version="1.0"?><Response xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><ID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</ID><Status>OK</Status><ProviderName>YOUR PROVIDER</ProviderName><DateTimeUTC>2008-10-09T00:59:11.1341229Z</DateTimeUTC><Invoice><Type>ACCREC</Type><InvoiceID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</InvoiceID><Contact><ContactID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</ContactID><ContactStatus>ACTIVE</ContactStatus><Name>CONTACT NAME</Name><EmailAddress>bob@example.com</EmailAddress><Addresses><Address><AddressType>POBOX</AddressType><AddressLine1>LINE 1 OF THE ADDRESS</AddressLine1><AddressLine2></AddressLine2><AddressLine3></AddressLine3><AddressLine4></AddressLine4><City>Somewhere</City><Region></Region><PostalCode></PostalCode><Country>Some Country</Country></Address></Addresses><Phones><Phone><PhoneType>MOBILE</PhoneType><PhoneNumber>1234567</PhoneNumber><PhoneAreaCode>123</PhoneAreaCode><PhoneCountryCode></PhoneCountryCode></Phone><Phone><PhoneType>DEFAULT</PhoneType><PhoneNumber></PhoneNumber><PhoneAreaCode></PhoneAreaCode><PhoneCountryCode></PhoneCountryCode></Phone><Phone><PhoneType>FAX</PhoneType><PhoneNumber></PhoneNumber><PhoneAreaCode></PhoneAreaCode><PhoneCountryCode></PhoneCountryCode></Phone><Phone><PhoneType>DDI</PhoneType><PhoneNumber></PhoneNumber><PhoneAreaCode></PhoneAreaCode><PhoneCountryCode></PhoneCountryCode></Phone></Phones></Contact><Date>2008-10-03T00:00:00</Date><DueDate>2008-10-20T00:00:00</DueDate><InvoiceNumber>INV-0001</InvoiceNumber><Reference></Reference><IncludesTax>true</IncludesTax><SubTotal>1000.0000</SubTotal><TotalTax>125.0000</TotalTax><Total>1125.0000</Total><InvoiceStatus>AUTHORISED</InvoiceStatus><LineItems><LineItem><LineItemID>e5a8a4ee-85ee-4532-a79f-a552ec63a0d7</LineItemID><Description>A LINE ITEM</Description><Quantity>100.0</Quantity><UnitAmount>12.34</UnitAmount><TaxType>OUTPUT</TaxType><TaxAmount>125.0000</TaxAmount><LineAmount>1125.0000</LineAmount><Tracking><TrackingCategory><Name>Region</Name><Option>Central</Option></TrackingCategory></Tracking></LineItem></LineItems><SentToContact>true</SentToContact></Invoice></Response>
+<?xml version="1.0"?>
+<Response xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <ID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</ID>
+  <Status>OK</Status>
+  <ProviderName>YOUR PROVIDER</ProviderName>
+  <DateTimeUTC>2008-10-09T00:59:11.1341229Z</DateTimeUTC>
+  <Invoice>
+    <Type>ACCREC</Type>
+    <InvoiceID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</InvoiceID>
+    <Contact>
+      <ContactID>a99a9aaa-9999-99a9-9aa9-aaaaaa9a9999</ContactID>
+      <ContactStatus>ACTIVE</ContactStatus>
+      <Name>CONTACT NAME</Name>
+      <EmailAddress>bob@example.com</EmailAddress>
+      <Addresses>
+        <Address>
+          <AddressType>POBOX</AddressType>
+          <AddressLine1>LINE 1 OF THE ADDRESS</AddressLine1>
+          <AddressLine2></AddressLine2>
+          <AddressLine3></AddressLine3>
+          <AddressLine4></AddressLine4>
+          <City>Somewhere</City>
+          <Region></Region>
+          <PostalCode></PostalCode>
+          <Country>Some Country</Country>
+        </Address>
+      </Addresses>
+      <Phones>
+        <Phone>
+          <PhoneType>MOBILE</PhoneType>
+          <PhoneNumber>1234567</PhoneNumber>
+          <PhoneAreaCode>123</PhoneAreaCode>
+          <PhoneCountryCode></PhoneCountryCode>
+        </Phone>
+        <Phone>
+          <PhoneType>DEFAULT</PhoneType>
+          <PhoneNumber></PhoneNumber>
+          <PhoneAreaCode></PhoneAreaCode>
+          <PhoneCountryCode></PhoneCountryCode>
+        </Phone>
+        <Phone>
+          <PhoneType>FAX</PhoneType>
+          <PhoneNumber></PhoneNumber>
+          <PhoneAreaCode></PhoneAreaCode>
+          <PhoneCountryCode></PhoneCountryCode>
+        </Phone>
+        <Phone>
+          <PhoneType>DDI</PhoneType>
+          <PhoneNumber></PhoneNumber>
+          <PhoneAreaCode></PhoneAreaCode>
+          <PhoneCountryCode></PhoneCountryCode>
+        </Phone>
+      </Phones>
+    </Contact>
+    <Date>2008-10-03T00:00:00</Date>
+    <DueDate>2008-10-20T00:00:00</DueDate>
+    <InvoiceNumber>INV-0001</InvoiceNumber>
+    <Reference></Reference>
+    <IncludesTax>true</IncludesTax>
+    <SubTotal>1000.0000</SubTotal>
+    <TotalTax>125.0000</TotalTax>
+    <Total>1125.0000</Total>
+    <InvoiceStatus>AUTHORISED</InvoiceStatus>
+    <LineItems>
+      <LineItem>
+        <LineItemID>e5a8a4ee-85ee-4532-a79f-a552ec63a0d7</LineItemID>
+        <Description>A LINE ITEM</Description>
+        <Quantity>100.0</Quantity>
+        <UnitAmount>12.34</UnitAmount>
+        <TaxType>OUTPUT</TaxType>
+        <TaxAmount>125.0000</TaxAmount>
+        <LineAmount>1125.0000</LineAmount>
+        <Tracking>
+          <TrackingCategory>
+            <Name>Region</Name>
+            <Option>Central</Option>
+          </TrackingCategory>
+        </Tracking>
+      </LineItem>
+    </LineItems>
+    <SentToContact>true</SentToContact>
+  </Invoice>
+</Response>


### PR DESCRIPTION
After a get_invoices, the line_items need to be lazy-downloaded when first requested on each invoice.

Invoice#line_items returned 'true' in this case, not a LineItem

This was caused by Invoice#download_line_items setting @line_items_downloaded after the wanted return value.
Fix, and add a test for this case.