### PR TITLE
Update the partner example to remove entrust certificates

### DIFF
--- a/examples/partner_app.rb
+++ b/examples/partner_app.rb
@@ -6,13 +6,9 @@ require File.dirname(__FILE__) + '/../lib/xero_gateway.rb'
 XERO_CONSUMER_KEY    = "YOUR CONSUMER KEY"
 XERO_CONSUMER_SECRET = "YOUR CONSUMER SERET"
 
-ENTRUST_CERT_NAME    = "YOUR_ENTRUST_CERT.pem"
-ENTRUST_KEY_NAME     = "YOUR_ENTRUST_KEY.pem"
 PRIVATE_KEY          = "YOUR_PRIVATE_KEY.pem"
 
 gateway = XeroGateway::PartnerApp.new(XERO_CONSUMER_KEY, XERO_CONSUMER_SECRET, 
-                                      :ssl_client_cert  => File.join(File.dirname(__FILE__), ENTRUST_CERT_NAME)
-                                      :ssl_client_key   => File.join(File.dirname(__FILE__), ENTRUST_KEY_NAME),
                                       :private_key_file => File.join(File.dirname(__FILE__), PRIVATE_KEY))
 
 # authorize in browser


### PR DESCRIPTION
https://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation