### PR TITLE
User agent mods

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -12,9 +12,9 @@ module XeroGateway
     #
     # The consumer key and secret here correspond to those provided
     # to you by Xero inside the API Previewer.
-    def initialize(consumer_key, consumer_secret, user_agent_base, options = {})
+    def initialize(consumer_key, consumer_secret, options = {})
       @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
-      @client   = OAuth.new(consumer_key, consumer_secret, user_agent_base, options)
+      @client   = OAuth.new(consumer_key, consumer_secret, options)
     end
 
     #

--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -12,9 +12,9 @@ module XeroGateway
     #
     # The consumer key and secret here correspond to those provided
     # to you by Xero inside the API Previewer.
-    def initialize(consumer_key, consumer_secret, options = {})
+    def initialize(consumer_key, consumer_secret, user_agent_base, options = {})
       @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
-      @client   = OAuth.new(consumer_key, consumer_secret, options)
+      @client   = OAuth.new(consumer_key, consumer_secret, user_agent_base, options)
     end
 
     #

--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -28,7 +28,7 @@ module XeroGateway
     def initialize(ctoken, csecret, options = {})
       @ctoken, @csecret = ctoken, csecret
       
-      #allow user-agent base val for certification procedure (enforce for PartnerApp)
+      # Allow user-agent base val for certification procedure (enforce for PartnerApp)
       @base_headers = {}
       @base_headers["User-Agent"] = options.delete(:user_agent) if options.has_key?(:user_agent)
 
@@ -40,11 +40,15 @@ module XeroGateway
     end
 
     def request_token(params = {})
+      # Underlying oauth consumer accepts body params and headers for request via positional params - explicit nilling of 
+      #  body parameters allows for correct position for headers
       @request_token ||= consumer.get_request_token(params, nil, @base_headers)
     end
 
     def authorize_from_request(rtoken, rsecret, params = {})
       request_token     = ::OAuth::RequestToken.new(consumer, rtoken, rsecret)
+      # Underlying oauth consumer accepts body params and headers for request via positional params - explicit nilling of 
+      #  body parameters allows for correct position for headers
       access_token      = request_token.get_access_token(params, nil, @base_headers)
       @atoken, @asecret = access_token.token, access_token.secret
 
@@ -67,6 +71,8 @@ module XeroGateway
 
       old_token = ::OAuth::RequestToken.new(consumer, access_token, access_secret)
 
+      # Underlying oauth consumer accepts body params and headers for request via positional params - explicit nilling of 
+      #  body parameters allows for correct position for headers
       access_token = old_token.get_access_token({
         :oauth_session_handle => session_handle,
         :token                => old_token

--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -25,12 +25,14 @@ module XeroGateway
     extend Forwardable
     def_delegators :access_token, :get, :post, :put, :delete
 
-    attr_reader   :ctoken, :csecret, :user_agent_base, :consumer_options, :authorization_expires_at
+    attr_reader   :ctoken, :csecret, :consumer_options, :authorization_expires_at
     attr_accessor :session_handle
 
-    def initialize(ctoken, csecret, user_agent_base, options = {})
-      @ctoken, @csecret, @user_agent_base = ctoken, csecret, user_agent_base      
+    def initialize(ctoken, csecret, options = {})
+      @ctoken, @csecret = ctoken, csecret
       @consumer_options = XERO_CONSUMER_OPTIONS.merge(options)
+      #allow user-agent base val for certification procedure (enforce for PartnerApp)
+      @user_agent_base_header = @consumer_options.has_key?(:user_agent) ? {"User-Agent" => @consumer_options[:user_agent]} : nil
     end
 
     def consumer
@@ -38,12 +40,12 @@ module XeroGateway
     end
 
     def request_token(params = {})
-      @request_token ||= consumer.get_request_token(params, nil, 'User-Agent' => user_agent_base)
+      @request_token ||= consumer.get_request_token(params, nil, user_agent_base_header)
     end
 
     def authorize_from_request(rtoken, rsecret, params = {})
       request_token     = ::OAuth::RequestToken.new(consumer, rtoken, rsecret)
-      access_token      = request_token.get_access_token(params, nil, 'User-Agent' => user_agent_base)
+      access_token      = request_token.get_access_token(params, nil, user_agent_base_header)
       @atoken, @asecret = access_token.token, access_token.secret
 
       update_attributes_from_token(access_token)
@@ -68,7 +70,7 @@ module XeroGateway
       access_token = old_token.get_access_token({
         :oauth_session_handle => session_handle,
         :token                => old_token
-      }, nil, 'User-Agent' => user_agent_base)
+      }, nil, user_agent_base_header)
 
       update_attributes_from_token(access_token)
     rescue ::OAuth::Unauthorized => e
@@ -77,6 +79,11 @@ module XeroGateway
       # situation the end user will need to re-authorize the application via the request token authorization URL
       raise XeroGateway::OAuth::TokenInvalid.new(e.message)
     end
+
+    protected
+      def user_agent_base_header
+        @user_agent_base_header
+      end
 
     private
 

--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -89,7 +89,7 @@ module XeroGateway
     end
       
     def put(path, body = '', headers = {})
-      access_token.put(path, body, headers.merge(@base_headerss))
+      access_token.put(path, body, headers.merge(@base_headers))
     end
     
     def delete(path, headers = {})

--- a/lib/xero_gateway/partner_app.rb
+++ b/lib/xero_gateway/partner_app.rb
@@ -2,16 +2,16 @@ module XeroGateway
   class PartnerApp < Gateway
 
     class CertificateRequired < StandardError; end
-    class UserAgentRequired < StandardError; end
 
     NO_PRIVATE_KEY_ERROR_MESSAGE = "You need to provide your private key (corresponds to the public key you uploaded at api.xero.com) as :private_key_file (should be .crt or .pem files)"
-    NO_USER_AGENT_ERROR_MESSAGE = "a unique User-Agent header is required for partner apps and should be supplied as :user_agent"
-
+    
     def_delegators :client, :session_handle, :renew_access_token, :authorization_expires_at
 
     def initialize(consumer_key, consumer_secret, options = {})
       raise CertificateRequired.new(NO_PRIVATE_KEY_ERROR_MESSAGE) unless options[:private_key_file]
-      raise UserAgentRequired.new(NO_USER_AGENT_ERROR_MESSAGE) unless options[:user_agent]
+      
+      #required by Xero for new partner apps, but only issuing warning to keep backward compat for any grandfathered apps
+      puts "WARNING: a unique User-Agent header is required for Xero partner apps, and is missing - this should be supplied as :user_agent" unless options[:user_agent]
 
       defaults = {
         :site             => "https://api.xero.com",

--- a/lib/xero_gateway/partner_app.rb
+++ b/lib/xero_gateway/partner_app.rb
@@ -5,11 +5,13 @@ module XeroGateway
     class UserAgentRequired < StandardError; end
 
     NO_PRIVATE_KEY_ERROR_MESSAGE = "You need to provide your private key (corresponds to the public key you uploaded at api.xero.com) as :private_key_file (should be .crt or .pem files)"
+    NO_USER_AGENT_ERROR_MESSAGE = "a unique User-Agent header is required for partner apps and should be supplied as :user_agent"
 
     def_delegators :client, :session_handle, :renew_access_token, :authorization_expires_at
 
-    def initialize(consumer_key, consumer_secret, user_agent_base, options = {})
+    def initialize(consumer_key, consumer_secret, options = {})
       raise CertificateRequired.new(NO_PRIVATE_KEY_ERROR_MESSAGE) unless options[:private_key_file]
+      raise UserAgentRequired.new(NO_USER_AGENT_ERROR_MESSAGE) unless options[:user_agent]
 
       defaults = {
         :site             => "https://api.xero.com",
@@ -18,7 +20,6 @@ module XeroGateway
       }
 
       options = defaults.merge(options)
-      options[:user_agent] = user_agent_base
 
       super(consumer_key, consumer_secret, defaults.merge(options))
     end

--- a/lib/xero_gateway/partner_app.rb
+++ b/lib/xero_gateway/partner_app.rb
@@ -2,12 +2,13 @@ module XeroGateway
   class PartnerApp < Gateway
 
     class CertificateRequired < StandardError; end
+    class UserAgentRequired < StandardError; end
 
     NO_PRIVATE_KEY_ERROR_MESSAGE = "You need to provide your private key (corresponds to the public key you uploaded at api.xero.com) as :private_key_file (should be .crt or .pem files)"
 
     def_delegators :client, :session_handle, :renew_access_token, :authorization_expires_at
 
-    def initialize(consumer_key, consumer_secret, options = {})
+    def initialize(consumer_key, consumer_secret, user_agent_base, options = {})
       raise CertificateRequired.new(NO_PRIVATE_KEY_ERROR_MESSAGE) unless options[:private_key_file]
 
       defaults = {
@@ -17,6 +18,7 @@ module XeroGateway
       }
 
       options = defaults.merge(options)
+      options[:user_agent] = user_agent_base
 
       super(consumer_key, consumer_secret, defaults.merge(options))
     end

--- a/test/unit/oauth_test.rb
+++ b/test/unit/oauth_test.rb
@@ -75,7 +75,7 @@ class OAuthTest < Test::Unit::TestCase
     xero.stubs(:consumer).returns(consumer)
   
     request_token = mock('request token')
-    consumer.expects(:get_request_token).with(:oauth_callback => "http://callback.com").returns(request_token)
+    consumer.expects(:get_request_token).with({:oauth_callback => "http://callback.com"}, nil, nil).returns(request_token)
   
     xero.request_token(:oauth_callback => "http://callback.com")
   end
@@ -91,7 +91,7 @@ class OAuthTest < Test::Unit::TestCase
     access_token.stubs(:params).returns({})
 
     request_token = mock('request token')
-    request_token.expects(:get_access_token).with(:oauth_verifier => "verifier").returns(access_token)
+    request_token.expects(:get_access_token).with({:oauth_verifier => "verifier"}, nil, nil).returns(access_token)
 
     OAuth::RequestToken.expects(:new).with(consumer, 'rtoken', 'rsecret').returns(request_token)
     


### PR DESCRIPTION
Updates to support custom User-Agent string (optional for public apps, mandatory for partner apps), as currently required by Xero for partner apps (shown [in docs](https://developer.xero.com/documentation/api-guides/certification-checkpoints#checkpoint3) and confirmed by support 09/07/2017).

Xero support has indicated there just needs to be an identifiable unique string in the User-Agent, and the additional parenthetical text added by the OAuth gem (e.g., " (OAuth gem v0.4.7)") is not a problem.