### PR TITLE
put sent_to_contact in XML

### DIFF
--- a/lib/xero_gateway/invoice.rb
+++ b/lib/xero_gateway/invoice.rb
@@ -195,7 +195,7 @@ module XeroGateway
           end
         }
         b.Url url if url
-        b.SentToContact sent_to_contact
+        b.SentToContact sent_to_contact unless sent_to_contact.nil?
       }
     end
 

--- a/lib/xero_gateway/invoice.rb
+++ b/lib/xero_gateway/invoice.rb
@@ -195,6 +195,7 @@ module XeroGateway
           end
         }
         b.Url url if url
+        b.SentToContact sent_to_contact
       }
     end
 


### PR DESCRIPTION
Currently you can't updated the `sent_to_contact` field, which is not great since that is part of the workaround for sending email invoices to contacts. https://developer.xero.com/documentation/api/invoices#emailing

This PR allows you to update this field.