### PR TITLE
Expose consumer issue

### DIFF
--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -99,7 +99,7 @@ module XeroGateway
         # a second.
         case (error_details["oauth_problem"].first)
           when "token_expired"        then raise OAuth::TokenExpired.new(description)
-          when "consumer_key_unknown" then raise OAuth::TokenInvalid.new(description)
+          when "consumer_key_unknown" then raise OAuth::ConsumerConfigError.new(description)
           when "token_rejected"       then raise OAuth::TokenInvalid.new(description)
           when "rate limit exceeded"  then raise OAuth::RateLimitExceeded.new(description)
           else

--- a/test/unit/gateway_test.rb
+++ b/test/unit/gateway_test.rb
@@ -176,7 +176,7 @@ class GatewayTest < Test::Unit::TestCase
     should "handle invalid consumer key" do
      XeroGateway::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("invalid_consumer_key"), :code => "401"))
 
-      assert_raises XeroGateway::OAuth::TokenInvalid do
+      assert_raises XeroGateway::OAuth::ConsumerConfigError do
         @gateway.get_accounts
       end
     end


### PR DESCRIPTION
Update to allow for differentiating an invalid user access token from bad consumer creds in `#renew_access_token` call.  Xero gives us this info in the response body from `POST https://api.xero.com/oauth/AccessToken` via body params (listed in https://developer.xero.com/documentation/auth-and-limits/oauth-issues), but current impl doesn't distinguish b/w these cases and eats the details.  

Allowing distinction allows a front-end to prompt a user to re-auth if their access token is bad, but not prompt if the problem is bad consumer creds (as those will continue to fail until a developer/admin fixes the issue).  Implementation details swiped from https://github.com/xero-gateway/xero_gateway/blob/master/lib/xero_gateway/http.rb#L90.