### PR TITLE
Link to accurate instructions to generate certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,7 @@ Private applications are used to access a single Xero account.
 
   Head to <https://api.xero.com>, log in and then click My Applications &gt; Add Application.
 
-  You'll need to generate an RSA keypair and an X509 certificate. This can be done with OpenSSL as below:
-
-  ```bash
-    openssl genrsa -out privatekey.pem
-    openssl req -newkey rsa:1024 -x509 -days 365 -in privatekey.pem -out publickey.cer
-  ```
+  You'll need to generate an RSA keypair and an X509 certificate. Follow the instructions [here](https://developer.xero.com/documentation/api-guides/create-publicprivate-key).
 
   You can then copy `publickey.cer` and paste it into the certificate box (`cat publickey.cer | pbcopy` on a Mac :apple:)
 


### PR DESCRIPTION
The instructions to generate a keypair / certificate did not work for me and I kept receiving invalid signature errors.  After some time shooting in the dark I tried the instructions on the xero docs site and everything worked.  I'm not sure why but there are slight differences in these instructions and the github local ones seem not to work on my environment (mac 10.11.6, ruby 2.4).