### PR TITLE
Adds the ability to get attributes for Report Cells

### DIFF
--- a/lib/xero_gateway/report.rb
+++ b/lib/xero_gateway/report.rb
@@ -1,5 +1,8 @@
+require_relative './report/cell'
+
 module XeroGateway
   class Report
+
     include Money
     include Dates
 
@@ -17,78 +20,93 @@ module XeroGateway
       end
     end
 
-    def self.from_xml(report_element)
-      report = Report.new
-      report_element.children.each do | element |
-        case element.name
-          when 'ReportID'         then report.report_id = element.text
-          when 'ReportName'       then report.report_name = element.text
-          when 'ReportType'       then report.report_type = element.text
-          when 'ReportTitles'
-            each_title(element) do |title|
-              report.report_titles << title
-            end
-          when 'ReportDate'       then report.report_date = Date.parse(element.text)
-          when 'UpdatedDateUTC'   then report.updated_at = parse_date_time_utc(element.text)
-          when 'Rows'
-            report.column_names   ||= find_body_column_names(element)
-            each_row_content(element) do |content_hash|
-              report.body << OpenStruct.new(content_hash)
-            end
+    class << self
+
+      def from_xml(report_element)
+        report = Report.new
+        report_element.children.each do | element |
+          case element.name
+            when 'ReportID'         then report.report_id = element.text
+            when 'ReportName'       then report.report_name = element.text
+            when 'ReportType'       then report.report_type = element.text
+            when 'ReportTitles'
+              each_title(element) do |title|
+                report.report_titles << title
+              end
+            when 'ReportDate'       then report.report_date = Date.parse(element.text)
+            when 'UpdatedDateUTC'   then report.updated_at = parse_date_time_utc(element.text)
+            when 'Rows'
+              report.column_names   ||= find_body_column_names(element)
+              each_row_content(element) do |content_hash|
+                report.body << OpenStruct.new(content_hash)
+              end
+          end
         end
+        report
       end
-      report
-    end
 
-  private
+      private
 
-    def self.each_row_content(xml_element, &block)
-      column_names   = find_body_column_names(xml_element).keys
-      xpath_body     = REXML::XPath.first(xml_element, "//RowType[text()='Section']").parent
-      rows_contents  = []
-      xpath_body.elements.each("Rows/Row") do |xpath_cells|
-        values        = find_body_cell_values(xpath_cells)
-        content_hash  = Hash[column_names.zip values]
-        rows_contents << content_hash
-        yield content_hash if block_given?
-      end
-      rows_contents
-    end
-
-    def self.each_title(xml_element, &block)
-      xpath_titles = REXML::XPath.first(xml_element, "//ReportTitles")
-      xpath_titles.elements.each("//ReportTitle") do |xpath_title|
-        title = xpath_title.text.strip
-        yield title if block_given?
-      end
-    end
-
-    def self.find_body_cell_values(xml_cells)
-      values = []
-      xml_cells.elements.each("Cells/Cell") do |xml_cell|
-        if value = xml_cell.children.first # finds <Value>...</Value>
-          values << value.text.try(:strip)
-          next
+        def each_row_content(xml_element, &block)
+          column_names   = find_body_column_names(xml_element).keys
+          xpath_body     = REXML::XPath.first(xml_element, "//RowType[text()='Section']").parent
+          rows_contents  = []
+          xpath_body.elements.each("Rows/Row") do |xpath_cells|
+            values        = find_body_cell_values(xpath_cells)
+            content_hash  = Hash[column_names.zip values]
+            rows_contents << content_hash
+            yield content_hash if block_given?
+          end
+          rows_contents
         end
-        values << nil
-      end
-      values
-    end
 
-    # returns something like { column_1: "Amount", column_2: "Description", ... }
-    def self.find_body_column_names(body)
-      header       = REXML::XPath.first(body, "//RowType[text()='Header']")
-      names_map    = {}
-      column_count = 0
-      header.parent.elements.each("Cells/Cell") do |header_cell|
-        column_count += 1
-        column_key    = "column_#{column_count}".to_sym
-        column_name   = nil
-        name_value    = header_cell.children.first
-        column_name   = name_value.text.strip unless name_value.blank? # finds <Value>...</Value>
-        names_map[column_key] = column_name
-      end
-      names_map
+        def each_title(xml_element, &block)
+          xpath_titles = REXML::XPath.first(xml_element, "//ReportTitles")
+          xpath_titles.elements.each("//ReportTitle") do |xpath_title|
+            title = xpath_title.text.strip
+            yield title if block_given?
+          end
+        end
+
+        def find_body_cell_values(xml_cells)
+          values = []
+          xml_cells.elements.each("Cells/Cell") do |xml_cell|
+            if value = xml_cell.children.first # finds <Value>...</Value>
+              values << Cell.new(value.text.try(:strip), collect_attributes(xml_cell))
+              next
+            end
+            values << nil
+          end
+          values
+        end
+
+        # Collects "<Attribute>" elements into a hash
+        def collect_attributes(xml_cell)
+          Array.wrap(xml_cell.elements["Attributes/Attribute"]).inject({}) do |hash, xml_attribute|
+            if (key   = xml_attribute.elements["Id"].try(:text)) &&
+              (value = xml_attribute.elements["Value"].try(:text))
+
+              hash[key] = value
+            end
+            hash
+          end.symbolize_keys
+        end
+
+        # returns something like { column_1: "Amount", column_2: "Description", ... }
+        def find_body_column_names(body)
+          header       = REXML::XPath.first(body, "//RowType[text()='Header']")
+          names_map    = {}
+          column_count = 0
+          header.parent.elements.each("Cells/Cell") do |header_cell|
+            column_count += 1
+            column_key    = "column_#{column_count}".to_sym
+            column_name   = nil
+            name_value    = header_cell.children.first
+            column_name   = name_value.text.strip unless name_value.blank? # finds <Value>...</Value>
+            names_map[column_key] = column_name
+          end
+          names_map
+        end
     end
 
   end

--- a/lib/xero_gateway/report/cell.rb
+++ b/lib/xero_gateway/report/cell.rb
@@ -1,0 +1,28 @@
+module XeroGateway
+  class Report
+
+    # Adds #attributes to the cells we're grabbing, since Xero Report Cells use XML like:
+    # <Cell>
+    #   <Value>Interest Income (270)</Value>
+    #   <Attributes>
+    #     <Attribute>
+    #       <Value>e9482110-7245-4a76-bfe2-14500495a076</Value>
+    #       <Id>account</Id>
+    #     </Attribute>
+    #   </Attributes>
+    # </Cell>
+    #
+    # We delegate to the topmost "<Value>" class and decorate with an "attributes" hash
+    # for the "attribute: value" pairs
+    class Cell < SimpleDelegator
+      attr_reader :attributes, :value
+
+      def initialize(value, new_attributes = {})
+        @value      = value
+        @attributes = new_attributes
+        super(value)
+      end
+    end
+
+  end
+end

--- a/test/stub_responses/reports/bank_statement.xml
+++ b/test/stub_responses/reports/bank_statement.xml
@@ -97,10 +97,12 @@
                   <Value>2014-05-01T00:00:00</Value>
                 </Cell>
                 <Cell>
-                  <Attribute>
-                    <Value>asasdas-asdf-asdf-asdf-asdfasdfasdfas</Value>
-                    <Id>statementID</Id>
-                  </Attribute>
+                  <Attributes>
+                    <Attribute>
+                      <Value>asasdas-asdf-asdf-asdf-asdfasdfasdfas</Value>
+                      <Id>statementID</Id>
+                    </Attribute>
+                  </Attributes>
                 </Cell>
                 <Cell>
                   <Value>Eft  </Value>


### PR DESCRIPTION
Note that this means that Report Cells are no longer core classes(e.g String), but are Report::Cell instances.

ReportCell is a SimpleDelegator to the type of the underlying value (usually String from Xero), but this may make strict equality tests fail.