### PR TITLE
added TLS 1.2 tests for gateway sdk

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -19,6 +19,13 @@ module XeroGateway
     end
 
     #
+    # A call against the test endpoint setup for enforcing TLS 1.2
+    # Used in gateway_test.rb
+    def get_tls_12_test(test_endpoint)
+      http_get(@client, test_endpoint, {})
+    end
+
+    #
     # Retrieve all contacts from Xero
     #
     # Usage : get_contacts(:order => :name)


### PR DESCRIPTION
Added a method & some tests for testing the SDK for TLS 1.2 usage.

See developer centre notice here: https://developer.xero.com/tls1-deprecation

These changes test against the Xero endpoint + an additional external API (https://www.howsmyssl.com/s/api.html) to determine that if TLS 1.2 is in use.

Open to comments / modifications / feedback