### PR TITLE
Email invoices

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -644,18 +644,9 @@ module XeroGateway
     #
     # Send an approved invoice from Xero
     #
-    def email_invoice(id, options = {})
-      request_params = {}
-      request_body = ""
-
-      raw_response = http_post(@client, "#{@xero_url}/Invoices/#{id}/Email", request_body, request_params)
-
-      response = XeroGateway::Response.new
-      response.status         = "OK"
-      response.request_params = request_params
-      response.request_xml    = request_body
-      response.response_xml   = raw_response
-      response
+    def email_invoice(id)
+      raw_response = http_post(@client, "#{@xero_url}/Invoices/#{id}/Email", "", {})
+      return raw_response == ""
     end
 
     private

--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -641,6 +641,23 @@ module XeroGateway
       parse_response(response_xml, {:request_params => request_params}, {:request_signature => 'GET/reports'})
     end
 
+    #
+    # Send an approved invoice from Xero
+    #
+    def email_invoice(id, options = {})
+      request_params = {}
+      request_body = ""
+
+      raw_response = http_post(@client, "#{@xero_url}/Invoices/#{id}/Email", request_body, request_params)
+
+      response = XeroGateway::Response.new
+      response.status         = "OK"
+      response.request_params = request_params
+      response.request_xml    = request_body
+      response.response_xml   = raw_response
+      response
+    end
+
     private
 
     def get_contact(contact_id = nil, contact_number = nil)

--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -73,6 +73,8 @@ module XeroGateway
             else
               response.plain_body
             end
+          when 204
+            nil
           when 400
             handle_error!(body, response)
           when 401

--- a/lib/xero_gateway/http.rb
+++ b/lib/xero_gateway/http.rb
@@ -74,7 +74,7 @@ module XeroGateway
               response.plain_body
             end
           when 204
-            nil
+            ""
           when 400
             handle_error!(body, response)
           when 401

--- a/test/integration/email_invoice_test.rb
+++ b/test/integration/email_invoice_test.rb
@@ -8,15 +8,12 @@ class EmailInvoiceTest < Test::Unit::TestCase
 
     if STUB_XERO_CALLS
       @gateway.xero_url = "DUMMY_URL"
-
-      @gateway.stubs(:http_post).with {|client, url, params| url =~ /Email$/ }.returns(nil)
+      @gateway.stubs(:http_post).with {|client, url, params| url =~ /Email$/ }.returns("")
     end
   end
 
   def test_email_invoice
     result = @gateway.email_invoice(dummy_invoice.invoice_id)
-
-    assert_kind_of XeroGateway::Response, result
-    assert result.success?
+    assert_equal true, result
   end
 end

--- a/test/integration/email_invoice_test.rb
+++ b/test/integration/email_invoice_test.rb
@@ -1,0 +1,22 @@
+require File.dirname(__FILE__) + '/../test_helper'
+
+class EmailInvoiceTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @gateway = XeroGateway::Gateway.new(CONSUMER_KEY, CONSUMER_SECRET)
+
+    if STUB_XERO_CALLS
+      @gateway.xero_url = "DUMMY_URL"
+
+      @gateway.stubs(:http_post).with {|client, url, params| url =~ /Email$/ }.returns(nil)
+    end
+  end
+
+  def test_email_invoice
+    result = @gateway.email_invoice(dummy_invoice.invoice_id)
+
+    assert_kind_of XeroGateway::Response, result
+    assert result.success?
+  end
+end


### PR DESCRIPTION
Send approved invoices from Xero.

Uses the beta [Email invoice API](https://developer.xero.com/documentation/api/invoices?emailbeta=true#emailing)

[Uservoice request](https://xero.uservoice.com/forums/5528-xero-api/suggestions/1930769-be-able-to-email-approved-invoices-via-the-api)

The response is 204 No Content, which I've had to fake to return a "success" response. Let me know if you want me to invent a new `XeroGateway::NoContentResponse` or similar instead.