### PR TITLE
Add support for page param when fetching bank transactions

### DIFF
--- a/lib/xero_gateway/gateway.rb
+++ b/lib/xero_gateway/gateway.rb
@@ -446,6 +446,7 @@ module XeroGateway
       request_params[:ModifiedAfter]      = options[:modified_since] if options[:modified_since]
       request_params[:order]              = options[:order] if options[:order]
       request_params[:where]              = options[:where] if options[:where]
+      request_params[:page]               = options[:page] if options[:page]
 
       response_xml = http_get(@client, "#{@xero_url}/BankTransactions", request_params)
 


### PR DESCRIPTION
As per Xero [API](https://developer.xero.com/documentation/api/banktransactions) docs, using pagination allows retrieving line_items for a transaction.