### PR TITLE
Avoid returning the InvoiceID of the first Payment for áll the returned Payments w/ using gateway.get_payments

### DIFF
--- a/lib/xero_gateway/base_record.rb
+++ b/lib/xero_gateway/base_record.rb
@@ -38,7 +38,7 @@ module XeroGateway
       end
 
       def from_xml(base_element, gateway = nil)
-        args = gateway ? [{ gateway: gateway }] : []
+        args = gateway ? [{ :gateway => gateway }] : []
         new(*args).from_xml(base_element)
       end
 

--- a/lib/xero_gateway/contact_group.rb
+++ b/lib/xero_gateway/contact_group.rb
@@ -69,7 +69,7 @@ module XeroGateway
     end
 
     def self.from_xml(contact_group_element, gateway, options = {})
-      contact_group = ContactGroup.new(gateway: gateway, contacts_downloaded: options[:contacts_downloaded])
+      contact_group = ContactGroup.new(:gateway => gateway, :contacts_downloaded => options[:contacts_downloaded])
       contact_group_element.children.each do |element|
         case(element.name)
           when "ContactGroupID" then contact_group.contact_group_id = element.text

--- a/lib/xero_gateway/payment.rb
+++ b/lib/xero_gateway/payment.rb
@@ -30,10 +30,10 @@ module XeroGateway
           when 'Reference'      then payment.reference = element.text
           when 'CurrencyRate'   then payment.currency_rate = BigDecimal(element.text)
           when 'Invoice'
-            payment.invoice_id = element.elements["//InvoiceID"].text
-            payment.invoice_number = element.elements["//InvoiceNumber"].text
+            payment.invoice_id = element.elements["InvoiceID"].text
+            payment.invoice_number = element.elements["InvoiceNumber"].text
           when 'IsReconciled'   then payment.reconciled = (element.text == "true")
-          when 'Account'        then payment.account_id = element.elements["//AccountID"].text
+          when 'Account'        then payment.account_id = element.elements["AccountID"].text
         end
       end
       payment

--- a/lib/xero_gateway/report.rb
+++ b/lib/xero_gateway/report.rb
@@ -1,5 +1,7 @@
-require_relative './report/cell'
-require_relative './report/row'
+require(File.expand_path('report/cell', File.dirname(__FILE__)))
+require(File.expand_path('report/row', File.dirname(__FILE__)))
+# require_relative './report/cell'
+# require_relative './report/row'
 
 module XeroGateway
   class Report

--- a/test/integration/get_payments_test.rb
+++ b/test/integration/get_payments_test.rb
@@ -27,6 +27,13 @@ class GetPaymentsTest < Test::Unit::TestCase
     assert_kind_of(XeroGateway::Payment, payment.first)
   end
 
+  def test_get_payments_gets_actual_invoice_ids
+    result = @gateway.get_payments
+    assert_not_equal result.payments[0].invoice_id, result.payments[1].invoice_id
+    # assert_equal result.payments[0].invoice_id, 'b0875d8b-ff26-4ce8-8aea-6955492ead48'
+    # assert_equal result.payments[1].invoice_id, '33c8d757-2db0-48a2-8daa-f54768fabeb1'
+  end
+
   def test_get_payments_modified_since_date
     # Create a test payment
     @gateway.create_payment(create_test_payment)


### PR DESCRIPTION
The XPaths used ("//SomeElement") made any node within the response match, but you only want to match from the child nodes...
Test included.

Sorry for also including my previous commit f68b950, just let me know if you want me to send a cleaner PR..