### PR TITLE
Avoid returning the same InvoiceID (a.o.) for all payments from get_payments

### DIFF
--- a/lib/xero_gateway/payment.rb
+++ b/lib/xero_gateway/payment.rb
@@ -31,7 +31,7 @@ module XeroGateway
           when 'CurrencyRate'   then payment.currency_rate = BigDecimal(element.text)
           when 'Invoice'
             payment.invoice_id = element.elements["InvoiceID"].text
-            payment.invoice_number = element.elements["InvoiceNumber"].text
+            payment.invoice_number = element.elements["InvoiceNumber"].try(:text)
           when 'IsReconciled'   then payment.reconciled = (element.text == "true")
           when 'Account'        then payment.account_id = element.elements["AccountID"].text
         end

--- a/lib/xero_gateway/payment.rb
+++ b/lib/xero_gateway/payment.rb
@@ -30,10 +30,10 @@ module XeroGateway
           when 'Reference'      then payment.reference = element.text
           when 'CurrencyRate'   then payment.currency_rate = BigDecimal(element.text)
           when 'Invoice'
-            payment.invoice_id = element.elements["//InvoiceID"].text
-            payment.invoice_number = element.elements["//InvoiceNumber"].text
+            payment.invoice_id = element.elements["InvoiceID"].text
+            payment.invoice_number = element.elements["InvoiceNumber"].text
           when 'IsReconciled'   then payment.reconciled = (element.text == "true")
-          when 'Account'        then payment.account_id = element.elements["//AccountID"].text
+          when 'Account'        then payment.account_id = element.elements["AccountID"].text
         end
       end
       payment

--- a/test/integration/get_payments_test.rb
+++ b/test/integration/get_payments_test.rb
@@ -27,6 +27,13 @@ class GetPaymentsTest < Test::Unit::TestCase
     assert_kind_of(XeroGateway::Payment, payment.first)
   end
 
+  def test_get_payments_gets_actual_invoice_ids
+    result = @gateway.get_payments
+    assert_not_equal result.payments[0].invoice_id, result.payments[1].invoice_id
+    # assert_equal result.payments[0].invoice_id, 'b0875d8b-ff26-4ce8-8aea-6955492ead48'
+    # assert_equal result.payments[1].invoice_id, '33c8d757-2db0-48a2-8daa-f54768fabeb1'
+  end
+
   def test_get_payments_modified_since_date
     # Create a test payment
     @gateway.create_payment(create_test_payment)

--- a/test/stub_responses/payments.xml
+++ b/test/stub_responses/payments.xml
@@ -52,5 +52,27 @@
         <InvoiceNumber>RPT469-1</InvoiceNumber>
       </Invoice>
     </Payment>
+    <Payment>
+      <PaymentID>d3b72ed1-4269-40a4-b0de-4be6fb3586c5</PaymentID>
+      <Date>2019-12-29T00:00:00</Date>
+      <Amount>142.00</Amount>
+      <CurrencyRate>1.000000</CurrencyRate>
+      <PaymentType>ACCPAYPAYMENT</PaymentType>
+      <Status>AUTHORISED</Status>
+      <UpdatedDateUTC>2019-12-02T10:48:51.15</UpdatedDateUTC>
+      <Account>
+        <AccountID>ac993f75-035b-433c-82e0-7b7a2d40802c</AccountID>
+        <Code>090</Code>
+      </Account>
+      <Invoice>
+        <Contact>
+          <ContactID>16b4cdc2-b36a-4b25-b9c8-7a50c17b10ba</ContactID>
+          <Name>Truxton Property Management</Name>
+        </Contact>
+        <CurrencyCode>NZD</CurrencyCode>
+        <Type>ACCPAY</Type>
+        <InvoiceID>c475f4c3-2b8b-4d44-b4fc-cbe7ee6fa9dd</InvoiceID>
+      </Invoice>
+    </Payment>
   </Payments>
 </Response>


### PR DESCRIPTION
The XPaths used ("//SomeElement") made any node within the response match, but you only want to match from the child nodes...
Test included.

This is a cleaned up version of PR #150; minus the commit that made the library 1.8 compatible again.